### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol server for code modification and generation. This server provides tools to create, modify, and delete code via Large Language Models.
 
+<a href="https://glama.ai/mcp/servers/pk7xbajohp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pk7xbajohp/badge" alt="mcp-server-code-assist MCP server" />
+</a>
+
 ### Tools
 
 1. `create`


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-code-assist](https://glama.ai/mcp/servers/pk7xbajohp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pk7xbajohp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pk7xbajohp/badge" alt="mcp-server-code-assist MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.